### PR TITLE
Add `:replace-deps` check for Clojure CLI tools.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,8 @@ All notable changes to this project will be documented in this file. This change
 
 == Unreleased (dev)
 
+* https://github.com/liquidz/antq/issues/44[#44]: Add `:replace-deps` check for Clojure CLI tools.
+
 == 0.9.2 (2020-12-05)
 // {{{
 === Changed

--- a/src/antq/dep/clojure.clj
+++ b/src/antq/dep/clojure.clj
@@ -35,7 +35,7 @@
         edn (edn/read-string deps-edn-content-str)]
     (walk/postwalk (fn [form]
                      (when (and (sequential? form)
-                                (#{:deps :extra-deps} (first form)))
+                                (#{:deps :extra-deps :replace-deps} (first form)))
                        (swap! deps merge (second form)))
                      form)
                    edn)


### PR DESCRIPTION
Check for new library versions when dependencies included via the :replace-deps
key in a deps.edn file

Successfully tested on https://github.com/practicalli/clojure-deps-edn

Resolves #44