### PR TITLE
Retry on some timeouts 

### DIFF
--- a/src/antq/diff/github_tag.clj
+++ b/src/antq/diff/github_tag.clj
@@ -10,12 +10,13 @@
       (first (filter #(str/includes? % target) coll))))
 
 (defmethod diff/get-diff-url :github-tag
-  [dep]
-  (let [url (format "https://github.com/%s"
-                    (str/join "/" (take 2 (str/split (:name dep) #"/"))))
-        tags (u.git/tags-by-ls-remote url)
-        current (or (exact-or-included tags (:version dep))
-                    (:version dep))
-        latest (or (exact-or-included tags (:latest-version dep))
-                   (:latest-version dep))]
-    (format "%s/compare/%s...%s" url current latest)))
+  [{:as dep :keys [version latest-version]}]
+  (when (and version latest-version)
+    (let [url (format "https://github.com/%s"
+                      (str/join "/" (take 2 (str/split (:name dep) #"/"))))
+          tags (u.git/tags-by-ls-remote url)
+          current (or (exact-or-included tags version)
+                      version)
+          latest (or (exact-or-included tags latest-version)
+                     latest-version)]
+      (format "%s/compare/%s...%s" url current latest))))

--- a/src/antq/util/git.clj
+++ b/src/antq/util/git.clj
@@ -1,19 +1,37 @@
 (ns antq.util.git
   (:require
+   [antq.log :as log]
    [clojure.java.shell :as sh]
    [clojure.string :as str]))
 
 (defn- extract-tags
   [ls-remote-resp]
-  (->> (:out ls-remote-resp)
-       (str/split-lines)
-       (keep #(second (str/split % #"\t" 2)))
-       (filter #(= 0 (.indexOf ^String % "refs/tags")))
-       (map #(str/replace % #"^refs/tags/" ""))))
+  (some->> (:out ls-remote-resp)
+           (str/split-lines)
+           (keep #(second (str/split % #"\t" 2)))
+           (filter #(= 0 (.indexOf ^String % "refs/tags")))
+           (map #(str/replace % #"^refs/tags/" ""))))
+
+(defn- sh-git-ls-remote
+  [url]
+  (loop [i 0]
+    (when (< i 5)
+      (let [{:keys [exit err] :as res} (sh/sh "git" "ls-remote" url)]
+        (cond
+          (= 0 exit)
+          res
+
+          (and (< 0 exit) (not (str/includes? err "Operation timed out")))
+          (log/error (str "git ls-remote failed on: " url))
+
+          :else
+          (do
+            (log/error "git ls-remote timed out, retrying")
+            (recur (inc i))))))))
 
 (defn tags-by-ls-remote*
   [url]
-  (-> (sh/sh "git" "ls-remote" url)
+  (-> (sh-git-ls-remote url)
       (extract-tags)))
 (def tags-by-ls-remote
   (memoize tags-by-ls-remote*))

--- a/test/antq/ver/github_tag_test.clj
+++ b/test/antq/ver/github_tag_test.clj
@@ -56,7 +56,8 @@
                           (throw (Exception. "test exception")))
                   sh/sh (fn [& args]
                           (when (= ["git" "ls-remote" "https://github.com/bar/baz"] args)
-                            {:out dummy-out}))]
+                            {:out dummy-out
+                             :exit 0}))]
       (t/testing "pre"
         (t/is (false? @api-errored))
         (t/is (false? @(deref #'sut/failed-to-fetch-from-api))))


### PR DESCRIPTION
This makes `antq` more robust against potential network failures and connections timing out.

My network connection is very, very dodgy at times:

`antq.util.maven/read-pom` and `antq.util.git/tags-by-ls-remote` would fail because the network times out.

`read-pom` would break the process and exit, and `tags-by-ls-remote` would fail silently, because the git process returns "no" tags.

Further, be more defensive in `diff/get-diff-url` when `:version` or `:latest-version` is nil, which happened for some of the deps in one of my projects. 