### PR TITLE
Handle errors gracefully when parsing GitHub version tags

### DIFF
--- a/src/antq/ver/github_tag.clj
+++ b/src/antq/ver/github_tag.clj
@@ -78,9 +78,17 @@
   [dep]
   (let [current (some-> dep :version u.ver/normalize-version version/version->seq)
         latest (some-> dep :latest-version u.ver/normalize-version version/version->seq)]
-    (when (and current latest)
-      (case (count (first current))
-        1 (nth-newer? current latest 0)
-        2 (and (nth-newer? current latest 0)
-               (nth-newer? current latest 1))
-        (<= 0 (version/version-seq-compare current latest))))))
+    (try
+      (when (and current latest)
+        (case (count (first current))
+          1 (nth-newer? current latest 0)
+          2 (and (nth-newer? current latest 0)
+                 (nth-newer? current latest 1))
+          (<= 0 (version/version-seq-compare current latest))))
+      (catch Throwable e
+        (log/error (format "Error determining latest version for GitHub dep %s (current: %s, latest: %s): %s"
+                           (pr-str (:name dep))
+                           (pr-str (:version dep))
+                           (pr-str (:latest-version dep))
+                           (ex-message e)))
+        true))))

--- a/src/antq/ver/github_tag.clj
+++ b/src/antq/ver/github_tag.clj
@@ -90,5 +90,5 @@
                            (pr-str (:name dep))
                            (pr-str (:version dep))
                            (pr-str (:latest-version dep))
-                           (ex-message e)))
+                           (.getMessage e)))
         true))))

--- a/test/antq/ver/github_tag_test.clj
+++ b/test/antq/ver/github_tag_test.clj
@@ -90,4 +90,8 @@
     false "2.2.4" "2.3.4"
     false "2.2" "2.3.4"
 
-    false "2.3.3" "2.3.4"))
+    false "2.3.3" "2.3.4"
+
+    ;; if version tag is unparseable, just log an error and return true.
+    true "v2.1.0" "v.2.x"
+    true "v.2.x" "v2.1.0"))


### PR DESCRIPTION
Fixes #98 (partially at least).

This change will log an error message if it's unable to parse GitHub version tags, then move on:

```
Error determining latest version for GitHub dep "octokit/request-action" (current: "v2.x", latest: "v2.1.0"): class java.lang.String cannot be cast to class java.lang.Number
```

This prevents the entire process from failing.

I don't know enough about the codebase to know what the expected behavior should actually be here, so please let me know if some other approach would be better. This is definitely an improvement over failing entirely tho IMO