### PR TITLE
Initial work around moving to tools build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,30 +19,23 @@ lint:
 	cljstyle check
 	clj-kondo --lint src:test
 
-.PHONY: pom
-pom:
-	clojure -Spom
-
-target/antq-standalone.jar: pom
-	clojure -X:depstar uberjar :jar $@ :aot true :main-class antq.core :aliases '[:nop]'
-
 .PHONY: uberjar
-uberjar: clean target/antq-standalone.jar
+uberjar:
+	clojure -T:build uberjar
 
-$(ARTIFACT): pom
-	clojure -X:depstar jar :jar $@
 .PHONY: jar
-jar: clean $(ARTIFACT)
+jar:
+	clojure -T:build jar
 
 .PHONY: install
-install: clean $(ARTIFACT)
-	clojure -X:deploy :installer :local :artifact $(ARTIFACT)
+install:
+	clojure -T:build install
 
 .PHONY: deploy
-deploy: clean $(ARTIFACT)
+deploy:
 	echo "Testing if CLOJARS_USERNAME environmental variable exists."
 	test $(CLOJARS_USERNAME)
-	clojure -X:deploy :installer :remote :artifact $(ARTIFACT)
+	clojure -T:build deploy
 
 .PHONY: docker
 docker:

--- a/deps.edn
+++ b/deps.edn
@@ -37,15 +37,10 @@
   {:extra-deps {cloverage/cloverage {:mvn/version "RELEASE"}}
    :main-opts ["-m" "cloverage.coverage" "--ns-exclude-regex" "leiningen.antq"]}
 
-  :depstar
-  {:extra-deps {com.github.seancorfield/depstar {:mvn/version "RELEASE"}}
-   :ns-default hf.depstar
-   :exec-args {}}
-
-  :deploy
-  {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
-   :exec-fn deps-deploy.deps-deploy/deploy
-   :exec-args {}}
+  :build
+  {:deps {io.github.seancorfield/build-clj {:git/tag "v0.6.7"
+                                            :git/sha "22c2d09"}}
+   :ns-default script.build}
 
   ;; -X
   :latest

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <packaging>jar</packaging>
   <groupId>com.github.liquidz</groupId>
   <artifactId>antq</artifactId>
-  <version>1.4.0</version>
+  <version>0.0.0</version>
   <name>antq</name>
   <description>Point out your outdated dependencies</description>
   <url>https://github.com/liquidz/antq</url>
@@ -17,54 +18,8 @@
     <url>https://github.com/liquidz/antq</url>
     <connection>scm:git:git://github.com/liquidz/antq.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/liquidz/antq.git</developerConnection>
+    <tag>0.0.0</tag>
   </scm>
-  <dependencies>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>data.json</artifactId>
-      <version>2.4.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>clojure</artifactId>
-      <version>1.10.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>tools.cli</artifactId>
-      <version>1.0.206</version>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>data.zip</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>rewrite-clj</groupId>
-      <artifactId>rewrite-clj</artifactId>
-      <version>1.0.699-alpha</version>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>tools.deps.alpha</artifactId>
-      <version>0.12.1090</version>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>data.xml</artifactId>
-      <version>0.2.0-alpha6</version>
-    </dependency>
-    <dependency>
-      <groupId>clj-commons</groupId>
-      <artifactId>clj-yaml</artifactId>
-      <version>0.7.107</version>
-    </dependency>
-    <dependency>
-      <groupId>version-clj</groupId>
-      <artifactId>version-clj</artifactId>
-      <version>2.0.2</version>
-    </dependency>
-  </dependencies>
   <build>
     <sourceDirectory>src</sourceDirectory>
   </build>

--- a/script/build.clj
+++ b/script/build.clj
@@ -1,0 +1,67 @@
+(ns script.build
+  (:require
+   [clojure.tools.build.api :as b]
+   [org.corfield.build :as bb]))
+
+(defn ^:private the-version
+  [patch]
+  (format "1.4.%s" patch))
+
+(def ^:private revs (Integer/parseInt (b/git-count-revs nil)))
+(def ^:private version (the-version revs))
+(def ^:private snapshot (the-version (format "%s-SNAPSHOT" (inc revs))))
+(def ^:private library 'com.github.liquidz/antq)
+
+(defn jar
+  "JAR the artifact.
+
+   This task will create the JAR in the `target` directory.
+   "
+  [{:keys [tag] :or {tag snapshot} :as opts}]
+  (-> opts
+      (assoc :lib library :version tag :tag tag)
+      (bb/clean)
+      (bb/jar)))
+
+(def ^:private config {:main 'antq.core
+                       :uber-file "target/antq.jar"})
+
+(defn uberjar
+  "UberJAR the application.
+
+   This task will create the UberJAR in the `target` directory.
+   "
+  [opts]
+  (-> (merge config opts)
+      (bb/clean)
+      (bb/uber)))
+
+(defn deploy
+  "Deploy the JAR to your local repository (proxy).
+
+   This task will build and deploy the JAR to your
+   local repository using `deps-deploy`. This requires
+   the following environment variables being set beforehand:
+
+   CLOJARS_URL, CLOJARS_USERNAME, CLOJARS_PASSWORD
+
+   Even although they are CLOJARS environment variables, they
+   can actually point to anywhere, like your own Nexus OSS repository
+   or an Artifactory repository for example.
+
+   You may want to consider something like `direnv` to manage your
+   per-directory loading of environment variables.
+   "
+  [{:keys [tag] :or {tag snapshot} :as opts}]
+  (-> opts
+      (assoc :lib library :version tag :tag tag)
+      (bb/deploy)))
+
+(defn install
+  "Deploy the JAR to your local .m2 directory"
+  [{:keys [tag] :or {tag snapshot} :as opts}]
+  (-> opts
+      (assoc :lib library
+             :version tag
+             :tag tag)
+      (bb/install)))


### PR DESCRIPTION
There are quite a few changes here.

1. The pom.xml is reduced down to the very bare minimum. The tools build will fill in the missing dependencies upon building the JAR.
2. It uses a CLJ script file (script/build.jar) to perform the JARing, UBERJARing, installing (locally) and installing to CLOJARS.
3. The makefile has been updated to call to the script file (via clojure -T:build ....) command.
4. Not sure how you feel, but the general trend I have observed (and one I follow myself) is to use MAJOR.MINOR.COMMITS as the version, so the so-called-patch version will always increase (and is basically the count of the git rev). Most of the tools I use follow that pattern. This is defined in the `script/build.clj` at the top of the script.

Some thought around the failing build, the static analysis is needed.

First step I suppose :-)

Fixes #143

-=david=-