### PR TITLE
Detect :default-deps for Clojure CLI

### DIFF
--- a/src/antq/constant.clj
+++ b/src/antq/constant.clj
@@ -1,3 +1,5 @@
 (ns antq.constant)
 
 (def retry-limit 5)
+
+(def clojure-deps-keys #{:deps :default-deps :extra-deps :override-deps :replace-deps})

--- a/src/antq/dep/clojure.clj
+++ b/src/antq/dep/clojure.clj
@@ -101,7 +101,7 @@
         cross-project-repositories (user-deps-repository)]
     (walk/postwalk (fn [form]
                      (when (and (sequential? form)
-                                (#{:deps :extra-deps :replace-deps :override-deps} (first form))
+                                (#{:deps :extra-deps :replace-deps :override-deps :default-deps} (first form))
                                 (map? (second form)))
                        (->> form
                             (second)

--- a/src/antq/dep/clojure.clj
+++ b/src/antq/dep/clojure.clj
@@ -1,6 +1,7 @@
 (ns antq.dep.clojure
   "Clojure CLI"
   (:require
+   [antq.constant :as const]
    [antq.record :as r]
    [antq.util.dep :as u.dep]
    [clojure.edn :as edn]
@@ -101,7 +102,7 @@
         cross-project-repositories (user-deps-repository)]
     (walk/postwalk (fn [form]
                      (when (and (sequential? form)
-                                (#{:deps :extra-deps :replace-deps :override-deps :default-deps} (first form))
+                                (const/clojure-deps-keys (first form))
                                 (map? (second form)))
                        (->> form
                             (second)

--- a/src/antq/upgrade/clojure.clj
+++ b/src/antq/upgrade/clojure.clj
@@ -1,5 +1,6 @@
 (ns antq.upgrade.clojure
   (:require
+   [antq.constant :as const]
    [antq.upgrade :as upgrade]
    [antq.util.dep :as u.dep]
    [antq.util.git :as u.git]
@@ -9,7 +10,7 @@
 (defn- in-deps?
   [loc]
   (->> loc z/up z/left z/sexpr
-       (contains? #{:deps :extra-deps :replace-deps :override-deps})))
+       (contains? const/clojure-deps-keys)))
 
 (defmulti replace-versions
   (fn [_loc version-checked-dep]


### PR DESCRIPTION
`:default-deps` is a resolve-deps modifier.

See https://clojure.org/reference/deps_and_cli#_resolve_deps_modifiers

It is sometimes used to indicate "managed-dependencies" or common pinned versions. See the following discussions

* https://ask.clojure.org/index.php/8440/equivalent-of-leiningens-managed-dependencies-in-deps-edn
* https://ask.clojure.org/index.php/9849/teams-common-dependencies-tooling-across-multiple-projects

`:default-deps` isn't used by the cli tool directly, but is a known argument in the tooling itself.

We use this internally to indicate managed dependencies and having antq detect `:default-deps` would be useful.