### PR TITLE
FIX: Strip whitespace from incoming pom files

### DIFF
--- a/src/antq/upgrade/pom.clj
+++ b/src/antq/upgrade/pom.clj
@@ -43,7 +43,7 @@
   [version-checked-dep]
   (-> (:file version-checked-dep)
       (io/input-stream)
-      (xml/parse)
+      (xml/parse :skip-whitespace true)
       (zip/xml-zip)
       (upgrade-dep version-checked-dep)
       (xml/indent-str)))

--- a/src/antq/upgrade/pom.clj
+++ b/src/antq/upgrade/pom.clj
@@ -2,7 +2,6 @@
   (:require
    [antq.upgrade :as upgrade]
    [clojure.data.xml :as xml]
-   [clojure.data.zip :as d.zip]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.zip :as zip]))
@@ -22,12 +21,10 @@
 
 (defn- edit-version
   [loc new-version]
-  (loop [loc (zip/right loc)]
-    (if (d.zip/rightmost? loc)
-      loc
-      (if (= "version" (some-> (zip/node loc) :tag name))
-        (zip/edit loc #(assoc % :content [new-version]))
-        (recur (zip/right loc))))))
+  (loop [loc loc]
+    (if (= "version" (some-> (zip/node loc) :tag name))
+      (zip/edit loc #(assoc % :content [new-version]))
+      (recur (zip/right loc)))))
 
 (defn upgrade-dep
   [loc version-checked-dep]


### PR DESCRIPTION
This issue was reported on `clojure-dependency-update-action`: https://github.com/nnichols/clojure-dependency-update-action/issues/11

When reading pom.xml files which were formatted, `clojure.data.xml` was adding extra nodes for the whitespace. After updating the file and writing it back with `clojure.data.xml`, those whitespace-only nodes were being written to the file, resulting in extra newlines in the result. 

`clojure-lsp` encountered the issue in this pull request: https://github.com/clojure-lsp/clojure-lsp/pull/854/files

I added the parsing option to remove the extra whitespace and then updated `edit-version` to start at the present node, rather than the node to its immediate right (since the first node is no longer just whitespace). 