### PR TITLE
Change leiningen example to use a dedicated profile

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -113,9 +113,9 @@ Add the following dependency and alias to your `$HOME/.lein/profiles.clj`.
 ----
 {
  :user
- {:dependencies [[com.github.liquidz/antq "RELEASE"]]
-  :aliases {"outdated" ["run" "-m" "antq.core"]}
-  }
+ {:aliases {"outdated" ["with-profile" "antq" "run" "-m" "antq.core"]}}
+ :antq
+ {:dependencies [[com.github.liquidz/antq "RELEASE"]]}
  }
 ----
 Then, run `lein outdated`.


### PR DESCRIPTION
Making antq deps part of the user profile makes transitive deps seep into the tasks ran by developers.  E.g. guava battles with the closure compiler used by clojurescript.