### PR TITLE
feature: access a private Maven repo with gpg in a Leiningen project

### DIFF
--- a/src/antq/util/leiningen.clj
+++ b/src/antq/util/leiningen.clj
@@ -1,7 +1,13 @@
 (ns antq.util.leiningen
   (:require
    [antq.util.env :as u.env]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [clojure.java.shell :as shell]
+   [clojure.java.io :as io]))
+
+(defn lein-home
+  []
+  (io/file (System/getProperty "user.home") ".lein"))
 
 (defn- env-name
   "cf. https://github.com/technomancy/leiningen/blob/master/doc/DEPLOY.md#credentials-in-the-environment"
@@ -16,6 +22,36 @@
 
     :else
     nil))
+
+(defn- gpg-program
+  []
+  (or (System/getenv "LEIN_GPG") "gpg"))
+
+(defn- gpg
+  [& args]
+  (try
+    (apply shell/sh (gpg-program) args)
+    (catch java.io.IOException e
+      {:exit 1 :err (.getMessage e)})))
+
+(defn- credentials-fn
+  "cf. https://leiningen.org/reference.html"
+  ([] (let [cred-file (io/file (lein-home) "credentials.clj.gpg")]
+        (if (.exists cred-file)
+          (credentials-fn cred-file))))
+  ([file]
+   (let [{:keys [out err exit]} (gpg "--quiet" "--batch"
+                                     "--decrypt" "--" (str file))]
+     (if (pos? exit)
+       (binding [*out* *err*]
+         (println "Could not decrypt credentials from" (str file))
+         (println err)
+         (println "See `lein help gpg` for how to install gpg."))
+       (read-string out)))))
+
+(defn read-credential
+  []
+  (credentials-fn))
 
 (defn env
   [kw]

--- a/src/antq/util/leiningen.clj
+++ b/src/antq/util/leiningen.clj
@@ -49,7 +49,7 @@
          (println "See `lein help gpg` for how to install gpg."))
        (read-string out)))))
 
-(defn read-credential
+(defn read-credentials
   []
   (credentials-fn))
 

--- a/src/antq/util/maven.clj
+++ b/src/antq/util/maven.clj
@@ -68,15 +68,9 @@
     (.setUsername (ensure-username-or-password username))
     (.setPassword (ensure-username-or-password password))))
 
-(defn- get-credential
-  []
-  (let [{:keys [username password]} (->> (u.lein/read-credential) vals first)]
-    {:username username
-     :password password}))
-
 (defn- get-auth-info
   [repository]
-  (let [[id {:keys [username password creds]}] repository]
+  (let [[id {:keys [url username password creds]}] repository]
     (cond
       (and username password)
       {:id id
@@ -84,7 +78,7 @@
        :password password}
 
       (= :gpg creds)
-      (let [credential-info (get-credential)]
+      (let [credential-info (u.lein/get-credential url)]
         {:id id
          :username (:username credential-info)
          :password (:password credential-info)}))))

--- a/src/antq/util/maven.clj
+++ b/src/antq/util/maven.clj
@@ -68,20 +68,42 @@
     (.setUsername (ensure-username-or-password username))
     (.setPassword (ensure-username-or-password password))))
 
+(defn- get-credential
+  []
+  (let [{:keys [username password]} (->> (u.lein/read-credential) vals first)]
+    {:username username
+     :password password}))
+
+(defn- get-auth-info
+  [repository]
+  (let [[id {:keys [username password creds]}] repository]
+    (cond
+      (and username password)
+      {:id id
+       :username username
+       :password password}
+
+      creds
+      (let [credential-info (get-credential)]
+        {:id id
+         :username (:username credential-info)
+         :password (:password credential-info)}))))
+
 (defn get-maven-settings
   ^Settings
   [opts]
   (let [settings ^Settings (deps.util.maven/get-settings)
         server-ids (set (map #(.getId %) (.getServers settings)))]
     ;; NOTE
-    ;; In Leiningen, authentication information is defined in project.clj instead of ~/.m2/settings.xml,
+    ;; In Leiningen, authentication information is defined in project.clj or profiles.clj instead of ~/.m2/settings.xml,
     ;; so if there is authentication information in `:repositories`, apply to `settings`
-    (doseq [[id {:keys [username password]}] (:repositories opts)]
-      (when (and username
-                 password
-                 (not (contains? server-ids id)))
-        (.addServer settings
-                    (new-repository-server {:id id :username username :password password}))))
+    (doseq [repo (:repositories opts)]
+      (let [{:keys [id username password]} (get-auth-info repo)]
+        (when (and username
+                   password
+                   (not (contains? server-ids id)))
+          (.addServer settings
+                      (new-repository-server {:id id :username username :password password})))))
     settings))
 
 (def ^TransferListener custom-transfer-listener

--- a/src/antq/util/maven.clj
+++ b/src/antq/util/maven.clj
@@ -83,7 +83,7 @@
        :username username
        :password password}
 
-      creds
+      (= :gpg creds)
       (let [credential-info (get-credential)]
         {:id id
          :username (:username credential-info)

--- a/test/antq/dep/leiningen_test.clj
+++ b/test/antq/dep/leiningen_test.clj
@@ -3,6 +3,7 @@
    [antq.constant.project-file :as const.project-file]
    [antq.dep.leiningen :as sut]
    [antq.record :as r]
+   [antq.util.leiningen :as u.lein]
    [clojure.java.io :as io]
    [clojure.test :as t]))
 
@@ -19,21 +20,22 @@
                             m)))
 
 (t/deftest extract-deps-test
-  (let [deps (sut/extract-deps
-              file-path
-              (slurp (io/resource "dep/test_project.clj")))]
-    (t/is (sequential? deps))
-    (t/is (every? #(instance? antq.record.Dependency %) deps))
-    (t/is (= (->> [(dependency {:name "foo/core" :version "1.0.0"})
-                   (dependency {:name "foo/core" :version "1.1.0"})
-                   (dependency {:name "bar/bar" :version "2.0.0"})
-                   (dependency {:name "baz/baz" :version "3.0.0"})
-                   (dependency {:name "plug/plug" :version "4.0.0"})
-                   (dependency {:name "managed/dependency" :version "5.0.0"})
-                   (dependency {:name "meta/range-ignore1" :version "6.0.0" :exclude-versions ["7.x"]})
-                   (dependency {:name "meta/range-ignore2" :version "7.0.0" :exclude-versions ["8.x" "9.x"]})]
-                  (sort-by :name))
-             (sort-by :name deps)))))
+  (with-redefs [u.lein/lein-home (fn [] "path/to/dummy/")]
+    (let [deps (sut/extract-deps
+                file-path
+                (slurp (io/resource "dep/test_project.clj")))]
+      (t/is (sequential? deps))
+      (t/is (every? #(instance? antq.record.Dependency %) deps))
+      (t/is (= (->> [(dependency {:name "foo/core" :version "1.0.0"})
+                     (dependency {:name "foo/core" :version "1.1.0"})
+                     (dependency {:name "bar/bar" :version "2.0.0"})
+                     (dependency {:name "baz/baz" :version "3.0.0"})
+                     (dependency {:name "plug/plug" :version "4.0.0"})
+                     (dependency {:name "managed/dependency" :version "5.0.0"})
+                     (dependency {:name "meta/range-ignore1" :version "6.0.0" :exclude-versions ["7.x"]})
+                     (dependency {:name "meta/range-ignore2" :version "7.0.0" :exclude-versions ["8.x" "9.x"]})]
+                    (sort-by :name))
+               (sort-by :name deps))))))
 
 (t/deftest load-deps-test
   (with-redefs [const.project-file/leiningen "test_project.clj"]

--- a/test/antq/dep/leiningen_test.clj
+++ b/test/antq/dep/leiningen_test.clj
@@ -20,7 +20,7 @@
                             m)))
 
 (t/deftest extract-deps-test
-  (with-redefs [u.lein/lein-home (fn [] "path/to/dummy/")]
+  (with-redefs [u.lein/lein-home (constantly "path/to/dummy/")]
     (let [deps (sut/extract-deps
                 file-path
                 (slurp (io/resource "dep/test_project.clj")))]

--- a/test/antq/util/leiningen_test.clj
+++ b/test/antq/util/leiningen_test.clj
@@ -10,7 +10,10 @@
     :password "one-password"}
    #"https://two.example.com/repository/.*"
    {:username "two-username"
-    :password "two-password"}})
+    :password "two-password"}
+   #"three.example.com/repository/"
+   {:username "three-username"
+    :password "three-password"}})
 
 (t/deftest env-test
   (with-redefs [u.env/getenv identity]
@@ -20,14 +23,17 @@
     (t/is (= nil (sut/env :invalid/foo_bar)))
     (t/is (= nil (sut/env "string")))))
 
-(t/deftest getp-credential-test
+(t/deftest get-credential-test
   (with-redefs [sut/credentials-fn (constantly dummy-credentials)]
     (let [url1 "https://one.example.com/repository/releases"
           url2 "https://two.example.com/repository/releases"
-          url3 "https://three.example.com/repository/releases"]
+          url3 "https://three.example.com/repository/releases"
+          url4 "https://four.example.com/repository/releases"]
       (t/is (= "one-username" (:username (sut/get-credential url1))))
       (t/is (= "one-password" (:password (sut/get-credential url1))))
       (t/is (= "two-username" (:username (sut/get-credential url2))))
       (t/is (= "two-password" (:password (sut/get-credential url2))))
-      (t/is (= nil (:username (sut/get-credential url3))))
-      (t/is (= nil (:password (sut/get-credential url3)))))))
+      (t/is (= "three-username" (:username (sut/get-credential url3))))
+      (t/is (= "three-password" (:password (sut/get-credential url3))))
+      (t/is (= nil (:username (sut/get-credential url4))))
+      (t/is (= nil (:password (sut/get-credential url4)))))))

--- a/test/antq/util/maven_test.clj
+++ b/test/antq/util/maven_test.clj
@@ -97,7 +97,7 @@
                  {:id "serv3" :username "three-user" :password "three-pass"}
                  ;; from project.clj with environmental variable
                  {:id "serv4" :username "lein-pass" :password "env-four"}
-                   ;; from profiles.clj with gpg
+                 ;; from profiles.clj with gpg
                  {:id "serv5" :username "gpg-user" :password "gpg-pass"}}
                (set servers))))))
 


### PR DESCRIPTION
Thank you for the amazing library 🎉 
I have a suggestion bellow.

## What

- Allow antq to read `~/.lein/profiles.clj`
- Allow antq to decrypt `credentials.clj.gpg`

## Why

- antq cannot resolve private maven repos listed in `profiles.clj`
- antq cannot decrypt `credentials.clj.gpg` to fetch artifact versions via leiningen

### Reploduction steps

1. Create the following Clojure code and save it as `/path/to/my-project/project.clj`:

```clojure
(defproject dep-test "0.0.1-SNAPSHOT"
  :dependencies [[my/private-lib "0.0.1"]]) ;; latest is `0.0.2`
```

2. Create the following Clojure code and save it as `~/.lein/profiles.clj`:
```clojure
;; Using GPG. ref: https://cljdoc.org/d/leiningen/leiningen/2.9.3/doc/using-gpg
{:user {:repositories [["internal-snapshots" {:url "https://my/private/repository"
                                              :creds :gpg}]]}}
```

3. Execute the following command:
```shell
$ clojure -M:outdated --directory="/path/to/my-project"
```

The output should be as follows:
```shell
| :file                           | :name              | :current | :latest         |
|---------------------------------+--------------------+----------+-----------------|
| /path/to/my-project/project.clj | my/private-lib     | 0.0.1    | Failed to fetch |
```
