### PR TITLE
Update tools.deps to 0.18.1398.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
   org.clojure/data.zip {:mvn/version "1.0.0"}
   org.clojure/tools.cli {:mvn/version "1.0.219"}
   org.clojure/core.async {:mvn/version "1.6.681"}
-  org.clojure/tools.deps {:mvn/version "0.18.1394"}
+  org.clojure/tools.deps {:mvn/version "0.18.1398"}
   org.clojure/data.json {:mvn/version "2.5.0"}
   clj-commons/clj-yaml {:mvn/version "1.0.27"}
   version-clj/version-clj {:mvn/version "2.0.2"}


### PR DESCRIPTION
Tools deps shipped with a spec that had a typo in it [1]. If the specs namespace of tools.deps is loaded, and instrumentation is turned on for a project, then the typo will cause an error.

I have a project that depends on antq which pulls in this bad spec and I can't run tests with instrumentation turned on.

This change updates tools.deps to fix this issue.

[1] https://github.com/clojure/tools.deps/commit/f71924e66a2561a8b22940d3dd52f08ef34e20ea
[2] https://ask.clojure.org/index.php/13601/typo-in-clojure-tools-deps-specs-claspath-args