### PR TITLE
Add option for outdated-deps API to accept file-path instead of hardcoding it to empty string

### DIFF
--- a/src/antq/api.clj
+++ b/src/antq/api.clj
@@ -21,10 +21,10 @@
       E.g. {\"clojars\" {:url \"https://clojars.org/repo\"}}"
   ([deps-map]
    (outdated-deps deps-map {}))
-  ([deps-map {:as options :keys [repositories]}]
+  ([deps-map {:as options :keys [repositories file-path] :or {file-path ""}}]
    (let [deps-edn (cond-> {:deps deps-map}
                     repositories (assoc :mvn/repos repositories))
-         antq-deps (dep.clojure/extract-deps "" (pr-str deps-edn))
+         antq-deps (dep.clojure/extract-deps file-path (pr-str deps-edn))
          antq-options (-> options
                           (dissoc :repositories)
                           (assoc :reporter report/no-output-reporter))]


### PR DESCRIPTION
Hi @liquidz it's me again 👋
Right now when using outdated-deps API function, as a result, we get the deps with :file set to empty string. 
And there is no option right now to provide for the API a file path.

This is hardcoded in extract-deps function call. My suggested change is non-breaking as I set a file-path defaulted to an empty string (as it was) and allow for setting it in the options map. 

Status: Tested works well