### PR TITLE
Add forced focus option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -210,6 +210,10 @@ NOTE: You must specify `groupId/artifactId` for Java dependencies.
 
 WARNING: `focus` option is prefer than `exclude` option.
 
+If you want to focus the upgrade on specific version of dependency, you can use --focus=ARTIFACT_NAME[@VERSION]
+E.g. `--focus=com.github.liquidz/antq@50.2.0`
+Will set antq dep to version 50.2.0, even if that version doesn't exist
+
 === --skip=PROJECT_TYPE
 Skip to search specified project files.
 Must be one of `boot`, `clojure-cli`, `github-action`, `pom`, `shadow-cljs` and `leiningen`.

--- a/src/antq/core.clj
+++ b/src/antq/core.clj
@@ -149,16 +149,16 @@
   (contains? #{"RELEASE" "master" "main" "latest"} (:version dep)))
 
 (defn mark-forced-version
-  "If dependency is in focused artifacts, sets `:forced-ver` information"
+  "If dependency is in focused artifacts, sets `:forced-version` information"
   [dep forced-artifacts]
-  (if-let [forced-ver (get forced-artifacts (:name dep))]
-    (assoc dep :forced-ver forced-ver)
+  (if-let [forced-version (get forced-artifacts (:name dep))]
+    (assoc dep :forced-version forced-version)
     dep))
 
 (defn- assoc-versions
   [dep options]
-  (let [res (if-let [forced-ver (:forced-ver dep)]
-              (assoc dep :_versions [forced-ver])
+  (let [res (if-let [forced-version (:forced-version dep)]
+              (assoc dep :_versions [forced-version])
               (assoc dep :_versions (ver/get-sorted-versions dep options)))]
     (report/run-progress dep options)
     res))
@@ -193,7 +193,7 @@
 (defn distinct-deps
   [deps]
   (->> deps
-       (map #(select-keys % [:type :name :version :repositories :extra :forced-ver]))
+       (map #(select-keys % [:type :name :version :repositories :extra :forced-version]))
        (map #(if (ver/snapshot? (:version %))
                %
                (dissoc % :version)))
@@ -222,7 +222,7 @@
                    (mapv #(mark-forced-version % forced-artifacts)))
         uniq-deps (distinct-deps org-deps)
         _ (report/init-progress uniq-deps options)
-        uniq-deps-with-vers (doall (pmap #(assoc-versions %  options) uniq-deps))
+        uniq-deps-with-vers (doall (pmap #(assoc-versions % options) uniq-deps))
         _ (report/deinit-progress uniq-deps options)
         assoc-latest-version* #(assoc-latest-version % options)
         version-checked-deps (->> org-deps
@@ -234,7 +234,7 @@
                               (keep :parent)
                               (set))]
     (->> version-checked-deps
-         (remove #(and (not (:forced-ver %))
+         (remove #(and (not (:forced-version %))
                        (ver/latest? %)
                        (not (contains? parent-dep-names (:name %))))))))
 

--- a/test/antq/core_test.clj
+++ b/test/antq/core_test.clj
@@ -197,7 +197,7 @@
       (t/is (= [(test-dep {:name "alice" :version "1.0.0" :latest-version "3.0.0"})]
                (sut/outdated-deps deps {:focus ["alice"]}))))
     (t/testing "focus containing specific version, should force it (0.5.0) even when newer exists (3.0.0)"
-      (t/is (= [(test-dep {:name "alice" :version "1.0.0" :latest-version "0.5.0" :forced-ver "0.5.0"})]
+      (t/is (= [(test-dep {:name "alice" :version "1.0.0" :latest-version "0.5.0" :forced-version "0.5.0"})]
                (sut/outdated-deps deps {:focus ["alice@0.5.0"]}))))))
 
 (t/deftest assoc-changes-url-test

--- a/test/antq/core_test.clj
+++ b/test/antq/core_test.clj
@@ -197,7 +197,7 @@
       (t/is (= [(test-dep {:name "alice" :version "1.0.0" :latest-version "3.0.0"})]
                (sut/outdated-deps deps {:focus ["alice"]}))))
     (t/testing "focus containing specific version, should force it (0.5.0) even when newer exists (3.0.0)"
-      (t/is (= [(test-dep {:name "alice" :version "1.0.0" :latest-version "0.5.0" :forced? true})]
+      (t/is (= [(test-dep {:name "alice" :version "1.0.0" :latest-version "0.5.0" :forced-ver "0.5.0"})]
                (sut/outdated-deps deps {:focus ["alice@0.5.0"]}))))))
 
 (t/deftest assoc-changes-url-test
@@ -326,7 +326,7 @@
 
 (t/deftest forced-artifacts-test
   (t/testing "default"
-    (t/is [] (sut/forced-artifacts {:focus ["foo"]}))
-    (t/is [{:name "foo" :latest-version "2.0.0"}] (sut/forced-artifacts {:focus ["foo@2.0.0"]}))
+    (t/is [] (sut/forced-artifact-version-map {:focus ["foo"]}))
+    (t/is [{:name "foo" :latest-version "2.0.0"}] (sut/forced-artifact-version-map {:focus ["foo@2.0.0"]}))
     (t/is [{:name "foo" :latest-version "2.0.0"}
-           {:name "foo/zbar2" :latest-version "2"}] (sut/forced-artifacts {:focus ["foo@2.0.0" "foo" "foo/bar" "foo/zbar2@2"]}))))
+           {:name "foo/zbar2" :latest-version "2"}] (sut/forced-artifact-version-map {:focus ["foo@2.0.0" "foo" "foo/bar" "foo/zbar2@2"]}))))


### PR DESCRIPTION
Hi, it's me again.

We've been using previously programmatic API, but due to compatibility issues with Babashka, we've moved to CLI. 
Currently, there is no option in CLI to force a specific version of the dependency to update.

Our use case to be more specific, is that we want to update to the non-existing yet version as we are deploying multiple co-dependent apps together. Which was possible in API by just supplying deps and target version we want it to update.

The CLI focus option seems best for me for that feature, as we want to focus on that dependency and update it to a specific version.
In terms of syntax, exclude follows a similar syntax of being able to exclude dep completely or specific version, currently focus was not leveraging the version option, so I've added this behavior under that versioning syntax.
`--focus=artifact[@VERSION]`

The feature was implemented in a manner that should not affect any existing behaviors that user may call. This is completely separate new feature.

Previously calling focus with `[@VERSION]` will result in empty deps to update, as it was considering whole string as a dependency name. Now if `@` appears, it considers it as forced-focus feature, otherwise as it was previously.

Example usage is described in .md and tests.
I use it like that:
Let's assume current version of artifact `org.clojars.hephaistox/automaton-build` in clojars is 3.1.0

I run
`clojure -M:antq --upgrade --force --focus=org.clojars.hephaistox/automaton-build@3.2.0`

And in my deps.edn,  I expect all references to org.clojars.hephaistox/automaton-build to be updated to 3.2.0
So whatever is set after @ in focus options is treated as source of truth for new version setting.