### PR TITLE
Next release

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,11 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of http://keepachangelog.com/[keepachangelog.com].
 
 == Unreleased (dev)
+// {{{
+=== Changed
+* Bumped deep-diff2 to 2.12.219.
+* Bumped tools.deps to 0.22.1492.
+// }}}
 
 == 2.11.1264 (2025-01-04)
 // {{{

--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
   org.clojure/data.zip {:mvn/version "1.1.0"}
   org.clojure/tools.cli {:mvn/version "1.1.230"}
   org.clojure/core.async {:mvn/version "1.7.701"}
-  org.clojure/tools.deps {:mvn/version "0.21.1467"}
+  org.clojure/tools.deps {:mvn/version "0.22.1492"}
   org.clojure/data.json {:mvn/version "2.5.1"}
   clj-commons/clj-yaml {:mvn/version "1.0.29"}
   version-clj/version-clj {:mvn/version "2.0.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -28,7 +28,7 @@
                  "test/resources"]
    :extra-deps {metosin/malli ^{:antq/exclude "0.17.0"} {:mvn/version "0.16.4"}
                 lambdaisland/kaocha {:mvn/version "1.91.1392"}
-                lambdaisland/deep-diff2 {:mvn/version "2.11.216"}}
+                lambdaisland/deep-diff2 {:mvn/version "2.12.219"}}
    :jvm-opts ["-Dclojure.core.async.go-checking=true"]}
 
   :nop


### PR DESCRIPTION
- **deps: Bump tools.deps to 0.22.1492**
- **deps: Bump deep-diff2 to 2.12.219**
- **docs: Update CHANGELOG**
