### PR TITLE
Change separator character to generate GH markdown table

### DIFF
--- a/src/antq/report/table.clj
+++ b/src/antq/report/table.clj
@@ -55,7 +55,7 @@
                            columns max-lengths))
     (println (->> max-lengths
                   (map #(apply str (repeat % "-")))
-                  (str/join "-+-")
+                  (str/join "-|-")
                   (format "|-%s-|")))
     (doseq [dep deps]
       (println (generate-row dep columns max-lengths)))))


### PR DESCRIPTION
I generated a report for a repository earlier today and used it as part of the description of a GH PR I was working on. It was _almost_ perfectly formatted as a GH-flavored Markdown table, and I just needed to change a few characters.

It occurred to me that while this is not a common usage, others probably want to do so on occasion, and this small change would simplify that usage without having a large negative impact on most anyone else.

This is just a suggested change, and I can certainly live without it.