### PR TITLE
Next release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        java: ['8', '11', '17']
+        java: ['11', '17', '21']
 
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,11 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of http://keepachangelog.com/[keepachangelog.com].
 
 == Unreleased (dev)
+// {{{
+=== Changed
+* https://github.com/liquidz/antq/pull/272[#272]: Change separator character in table reporter to generate GH markdown table.
+* Bumped tools.deps to 0.23.1512.
+// }}}
 
 == 2.11.1269 (2025-02-23)
 // {{{

--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
   org.clojure/data.zip {:mvn/version "1.1.0"}
   org.clojure/tools.cli {:mvn/version "1.1.230"}
   org.clojure/core.async {:mvn/version "1.7.701"}
-  org.clojure/tools.deps {:mvn/version "0.22.1492"}
+  org.clojure/tools.deps {:mvn/version "0.23.1512"}
   org.clojure/data.json {:mvn/version "2.5.1"}
   clj-commons/clj-yaml {:mvn/version "1.0.29"}
   version-clj/version-clj {:mvn/version "2.0.3"}


### PR DESCRIPTION
- **deps: Bump tools.deps to 0.23.1512**
- **test: Update test workflow to test with java 11, 17, and 21**
- **docs: Update CHANGELOG**
