### PR TITLE
docs:  review/update with cljdoc.org in mind

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -177,6 +177,7 @@ See link:./doc/gradle.adoc[our Gradle docs] for details.
 Antq has timeouts for acquiring various information.
 See link:./doc/timeout.adoc[Timeouts] for details.
 
+[[options]]
 == Options
 
 [TIP]

--- a/README.adoc
+++ b/README.adoc
@@ -84,7 +84,8 @@ See <<opt-check-clojure-tools>> option.
 Run the following command to quickly try antq:
 [source,sh]
 ----
-clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' -M -m antq.core
+clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' \
+  -M -m antq.core
 ----
 
 Or add the following alias to your project `deps.edn` or `$HOME/.clojure/deps.edn`.
@@ -400,9 +401,9 @@ Otherwise, it may take a long time for the results to be reported.
 
 == Tips
 
-* link:./doc/maven-s3-repos.adoc[Maven S3 repos].
+* link:./doc/maven-s3-repos.adoc[Maven S3 repos]
 * link:./doc/avoid-slf4j-warnings.adoc[Quiet SLF4J logger warnings]
-* link:./doc/latest-version-of-a-specific-library.adoc[Latest version of a specific library]
+* link:./doc/latest-version-of-a-specific-library.adoc[Find the latest version of a library]
 * link:./doc/non-supported-clojure-version.adoc[Antq on projects that use old versions of Clojure]
 * link:./doc/gradle.adoc[Working with Gradle]
 * link:./doc/proxy.adoc[Running behind a proxy]

--- a/README.adoc
+++ b/README.adoc
@@ -399,15 +399,15 @@ Otherwise, it may take a long time for the results to be reported.
 
 == Tips
 
-* link:./doc/maven-s3-repos.adoc[Maven S3 reposhere].
-* link:./doc/avoid-slf4j-warnings.adoc[Avoid SLF4J warnings]
+* link:./doc/maven-s3-repos.adoc[Maven S3 repos].
+* link:./doc/avoid-slf4j-warnings.adoc[Quiet SLF4J logger warnings]
 * link:./doc/latest-version-of-a-specific-library.adoc[Latest version of a specific library]
-* link:./doc/non-supported-clojure-version.adoc[Antq with non supported Clojure version]
-* link:./doc/gradle.adoc[Work with Gradle]
-* link:./doc/proxy.adoc[Run behind proxy]
+* link:./doc/non-supported-clojure-version.adoc[Antq on projects that use old versions of Clojure]
+* link:./doc/gradle.adoc[Working with Gradle]
+* link:./doc/proxy.adoc[Running behind a proxy]
 * link:./doc/timeout.adoc[Timeouts]
-* link:./doc/exclusions.adoc[Exclusions]
-* link:./doc/use-as-library.adoc[Use antq as a library]
+* link:./doc/exclusions.adoc[Excluding dependencies]
+* link:./doc/use-as-library.adoc[Using antq as a library]
 
 == License
 

--- a/README.adoc
+++ b/README.adoc
@@ -9,6 +9,7 @@ image:https://github.com/liquidz/antq/workflows/lint/badge.svg["GitHub Actions f
 image:https://github.com/liquidz/antq/workflows/dependencies/badge.svg["GitHub Actions for dependencies workflow", link="https://github.com/liquidz/antq/actions?query=workflow%3Adependencies"]
 image:https://codecov.io/gh/liquidz/antq/branch/master/graph/badge.svg["codecov", link="https://codecov.io/gh/liquidz/antq"]
 
+image:https://cljdoc.org/badge/com.github.liquidz/antq["cljdoc", link="https://cljdoc.org/d/com.github.liquidz/antq"]
 image:https://img.shields.io/clojars/v/com.github.liquidz/antq["Clojars Project", link="https://clojars.org/com.github.liquidz/antq"]
 image:https://img.shields.io/badge/docker-automated-blue["GitHub Container Registry", link="https://github.com/users/liquidz/packages/container/package/antq"]
 

--- a/README.adoc
+++ b/README.adoc
@@ -95,7 +95,7 @@ Or add the following alias to your project `deps.edn` or `$HOME/.clojure/deps.ed
  {:outdated {;; Note that it is `:deps`, not `:extra-deps`
              :deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
              :main-opts ["-m" "antq.core"]}}
- }
+}
 ----
 Then, run `clojure -M:outdated`.
 (run `clojure -A:outdated` for Clojure CLI Tool 1.10.1.645 or earlier).

--- a/doc/avoid-slf4j-warnings.adoc
+++ b/doc/avoid-slf4j-warnings.adoc
@@ -1,6 +1,6 @@
 = Quiet SLF4J logger warnings
 
-It is not antq place to specify a logger, so depending our your project, you may see the following messages when antq is run:
+It is not antq's place to specify a logger, so depending our your project, you may see the following messages when antq is run:
 
 [source,text]
 ----

--- a/doc/avoid-slf4j-warnings.adoc
+++ b/doc/avoid-slf4j-warnings.adoc
@@ -1,4 +1,4 @@
-= Avoid SLF4J warnings
+= Quiet SLF4J logger warnings
 
 antq does not load `org.slf4j.impl.StaticLoggerBinder` by default, so you may get following messages depending on the project.
 

--- a/doc/avoid-slf4j-warnings.adoc
+++ b/doc/avoid-slf4j-warnings.adoc
@@ -1,6 +1,6 @@
 = Quiet SLF4J logger warnings
 
-antq does not load `org.slf4j.impl.StaticLoggerBinder` by default, so you may get following messages depending on the project.
+Antq does not load `org.slf4j.impl.StaticLoggerBinder` by default, so you may get following messages depending on the project.
 
 [source,text]
 ----

--- a/doc/avoid-slf4j-warnings.adoc
+++ b/doc/avoid-slf4j-warnings.adoc
@@ -1,6 +1,6 @@
 = Quiet SLF4J logger warnings
 
-Antq does not load `org.slf4j.impl.StaticLoggerBinder` by default, so you may get following messages depending on the project.
+It is not antq place to specify a logger, so depending our your project, you may see the following messages when antq is run:
 
 [source,text]
 ----
@@ -9,9 +9,28 @@ SLF4J: Defaulting to no-operation (NOP) logger implementation
 SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
 ----
 
-To avoid this message, add the following to your dependency.
+You can avoid these message by specifying a logger.
 
+Add the nop logger to suppress all logging output:
 [source,clojure]
 ----
 org.slf4j/slf4j-nop {:mvn/version "RELEASE"}
+----
+
+Or add the simple logger that will log to stdout:
+[source,clojure]
+----
+org.slf4j/slf4j-simple {:mvn/version "RELEASE"}
+----
+
+This logger dependency should be added under the context which antq runs, for example for link:../README.adoc#usage-clojure-cli[`deps.edn`] this would look like:
+
+[source,clojure]
+----
+{
+ :aliases
+ {:outdated {:deps {org.slf4j/slf4j-simple {:mvn/version "RELEASE"}
+                    com.github.liquidz/antq {:mvn/version "RELEASE"}}
+             :main-opts ["-m" "antq.core"]}}
+}
 ----

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,0 +1,13 @@
+{:cljdoc.doc/tree
+ [["Readme" {:file "README.adoc"}]
+  ["Changelog" {:file "CHANGELOG.adoc"}]
+  ["Tips" {}
+   ["Maven S3 repos" {:file "doc/maven-s3-repos.adoc"}]
+   ["Quiet SLF4J logger warnings" {:file "doc/avoid-slf4j-warnings.adoc"}]
+   ["Find the latest version of a library" {:file "doc/latest-version-of-a-specific-library.adoc"}]
+   ["Antq on projects that use an old version of Clojure" {:file "doc/non-supported-clojure-version.adoc"}]
+   ["Working with Gradle" {:file "doc/gradle.adoc"}]
+   ["Running behind a proxy" {:file "doc/proxy.adoc"}]
+   ["Timeouts" {:file "doc/timeout.adoc"}]
+   ["Excluding dependencies" {:file "doc/exclusions.adoc"}]
+   ["Using antq as a library" {:file "doc/use-as-library.adoc"}]]]}

--- a/doc/exclusions.adoc
+++ b/doc/exclusions.adoc
@@ -1,8 +1,6 @@
-= Exclusions
+= Excluding dependencies
 
-When you'd like to exclude specific dependencies, you could `--exclude` option as you know.
-
-Otherwise, the following ways are available.
+When you'd like to exclude specific dependencies, you can use the link:../README.adoc#opt-exclude[--exclude] option, or one of the methods describe below.
 
 == Metadata in your project file
 

--- a/doc/gradle.adoc
+++ b/doc/gradle.adoc
@@ -11,7 +11,7 @@ WARNING: Gradle support is experimental
 
 To work with gradle, you should update your `build.gradle` as following.
 
-[source,build.gradle]
+[source,groovy]
 ----
 plugins {
   id 'java-library'

--- a/doc/gradle.adoc
+++ b/doc/gradle.adoc
@@ -1,4 +1,4 @@
-= Work with Gradle
+= Working with Gradle
 
 WARNING: Gradle support is experimental
 

--- a/doc/latest-version-of-a-specific-library.adoc
+++ b/doc/latest-version-of-a-specific-library.adoc
@@ -1,4 +1,4 @@
-= Latest version of a specific library
+= Find the latest version of a library
 
 If you are using Clojure CLI Tools https://clojure.org/releases/tools#v1.10.1.697[v1.10.1.697] or later,
 You can use `-X` option to find out the latest version of a specific library.

--- a/doc/latest-version-of-a-specific-library.adoc
+++ b/doc/latest-version-of-a-specific-library.adoc
@@ -3,13 +3,16 @@
 If you are using Clojure CLI Tools https://clojure.org/releases/tools#v1.10.1.697[v1.10.1.697] or later,
 You can use `-X` option to find out the latest version of a specific library.
 
-[source,shell]
+Try to find Java library by default:
+[source,clojure]
 ----
-# Try to find Java library by default
 clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' \
   -X antq.core/latest :name antq
+----
 
-# You can specify library type
+You can specify library type:
+[source,clojure]
+----
 clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' \
   -X antq.core/latest :name actions/checkout :type :github-tag
 ----

--- a/doc/latest-version-of-a-specific-library.adoc
+++ b/doc/latest-version-of-a-specific-library.adoc
@@ -3,12 +3,14 @@
 If you are using Clojure CLI Tools https://clojure.org/releases/tools#v1.10.1.697[v1.10.1.697] or later,
 You can use `-X` option to find out the latest version of a specific library.
 
-[source,clojure]
+[source,shell]
 ----
-;; Try to find Java library by default
-clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' -X antq.core/latest :name antq
+# Try to find Java library by default
+clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' \
+  -X antq.core/latest :name antq
 
-;; You can specify library type
-clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' -X antq.core/latest :name actions/checkout :type :github-tag
+# You can specify library type
+clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' \
+  -X antq.core/latest :name actions/checkout :type :github-tag
 ----
 

--- a/doc/maven-s3-repos.adoc
+++ b/doc/maven-s3-repos.adoc
@@ -3,7 +3,7 @@
 Antq supports Maven S3 repositories as same as https://clojure.org/reference/deps_and_cli[tools.deps].
 To use Maven S3 repositories, add repositories to your project configuration.
 
-Please see https://clojure.org/reference/deps_and_cli#_maven_s3_repos[tools.deps documents] documents for AWS S3 credentials.
+Please see https://clojure.org/reference/clojure_cli#mvn_s3_repo[tools.deps documents] documents for AWS S3 credentials.
 
 .Clojure CLI Tool (deps.edn)
 [source,clojure]

--- a/doc/non-supported-clojure-version.adoc
+++ b/doc/non-supported-clojure-version.adoc
@@ -1,15 +1,23 @@
-= Antq with non supported Clojure version
+= Antq on projects that use an old version of Clojure 
 
-As described, antq does not support Clojure 1.9.0 or earlier.
-If you'd like to use, please follow the steps below.
+Antq does not support Clojure 1.10.0 or earlier.
+You can still use antq on these older projects; follow the steps below. 
 
 == Clojure CLI
 
-Please use `:deps`, not `:extra-deps`.
+Use `:deps`, not `:extra-deps`.
+This will use the default Clojure cli version, instead of the older Clojure version on which your project depends.
 
-So the Clojure version which your project depends will not be used when antq is run.
+TIP: This assumes your installed Clojure cli version is 1.10 or later.
 
-If you must use `:extra-deps`, please add the new version of Clojure explicitly in an alias that uses antq as follows.
+[source,clojure]
+----
+{:aliases {:outdated {:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
+                      :main-opts ["-m" "antq.core"]}}}
+----
+
+
+If you must use `:extra-deps`, add an antq supported version of Clojure explicitly in an alias that uses antq as follows.
 
 [source,clojure]
 ----

--- a/doc/proxy.adoc
+++ b/doc/proxy.adoc
@@ -1,11 +1,11 @@
-= Run behind proxy
+= Running behind a proxy
 
-antq uses the proxy setting defined in `~/.m2/setting.xml`.
+Antq uses the proxy setting defined in `~/.m2/setting.xml`.
 
 So if you'd like to run antq behind proxy, please add a proxy setting like below.
 
 E.g.
-[source,setting.xml]
+[source,xml]
 ----
 <settings>
   <proxies>

--- a/doc/timeout.adoc
+++ b/doc/timeout.adoc
@@ -3,33 +3,33 @@
 Antq has timeouts for acquiring various information.
 These timeouts are customizable by following environmental variables.
 
-[cols="1,4a,5a"]
+[%autowidth]
 |===
-| Name | Default | Description
+| Name | Default | Unit | For 
 
-| ANTQ_DEFAULT_TIMEOUT
-| `10,000`
-| Unit is milli sec.
+| `ANTQ_DEFAULT_TIMEOUT`
+| `10000`
+| milliseconds
+| 
 
+| `ANTQ_LS_REMOTE_TIMEOUT`
+| `ANTQ_DEFAULT_TIMEOUT`
+| milliseconds
+| `git ls-remote`
 
-| ANTQ_LS_REMOTE_TIMEOUT
-| Same as `ANTQ_DEFAULT_TIMEOUT`.
-| Timeout for `git ls-remote`. +
-  Unit is milli sec.
+| `ANTQ_GITHUB_API_TIMEOUT`
+| `ANTQ_DEFAULT_TIMEOUT`
+| milliseconds
+| GitHub API
 
-| ANTQ_GITHUB_API_TIMEOUT
-| Same as `ANTQ_DEFAULT_TIMEOUT`.
-| Timeout for GitHub API. +
-  Unit is milli sec.
+| `ANTQ_MAVEN_TIMEOUT`
+| `ANTQ_DEFAULT_TIMEOUT`
+| milliseconds
+| Accessing Maven repositories
 
-| ANTQ_MAVEN_TIMEOUT
-| Same as `ANTQ_DEFAULT_TIMEOUT`.
-| Timeout for accessing Maven repositories. +
-  Unit is milli sec.
-
-| ANTQ_POM_TIMEOUT
-| Same as `ANTQ_DEFAULT_TIMEOUT`.
-| Timeout for reading POM. +
-  Unit is milli sec.
+| `ANTQ_POM_TIMEOUT`
+| `ANTQ_DEFAULT_TIMEOUT`
+| milliseconds
+| Reading POM
 
 |===

--- a/doc/use-as-library.adoc
+++ b/doc/use-as-library.adoc
@@ -2,11 +2,11 @@
 
 Antq is a tool to point out your outdated dependencies, but you can also use it as a library.
 
-== https://github.com/liquidz/antq/blob/main/src/antq/api.clj[antq.api]
+== antq.api
 
-The namespace `antq.api` provides the main functions to use antq as a library.
+The link:https://cljdoc.org/d/com.github.liquidz/antq/CURRENT/api/antq.api[`antq.api`] namespace provides is our only supported public API when using antq as library.
 
 * `outdated-deps`
-** Returns outdated dependencies in the form of `antq.record.Dependency`.
+** Returns a map of outdated dependencies
 * `upgrade-deps!`
 ** Upgrade version strings in specified files.

--- a/doc/use-as-library.adoc
+++ b/doc/use-as-library.adoc
@@ -1,4 +1,4 @@
-= Use antq as a library
+= Using antq as a library
 
 Antq is a tool to point out your outdated dependencies, but you can also use it as a library.
 

--- a/doc/use-as-library.adoc
+++ b/doc/use-as-library.adoc
@@ -4,7 +4,7 @@ Antq is a tool to point out your outdated dependencies, but you can also use it 
 
 == antq.api
 
-The link:https://cljdoc.org/d/com.github.liquidz/antq/CURRENT/api/antq.api[`antq.api`] namespace provides is our only supported public API when using antq as library.
+The link:https://cljdoc.org/d/com.github.liquidz/antq/CURRENT/api/antq.api[`antq.api`] namespace is our only supported public API when using antq as library and eposes the following functions:
 
 * `outdated-deps`
 ** Returns a map of outdated dependencies

--- a/src/antq/api.clj
+++ b/src/antq/api.clj
@@ -7,12 +7,28 @@
    [antq.util.file :as u.file]))
 
 (defn outdated-deps
-  "Returns outdated dependencies in the form of `antq.record.Dependency`.
+  ;; since records can't have docstrings we'll describe the Dependency record for our users here
+  ;; we'll consider the fact that it is a record an implementation detail and describe as map
+  "Returns a sequence of maps describing outdated dependencies: 
+  - `:type` _keyword_ dependency type: `:git-sha`, `:git-tag-and-sha`, `:github-tag` `:java`, or `:circle-ci-orb`
+  - `:file` _string_ file path for project configuration file
+  - `:name` _string_ dependency name, .e.g., `\"org.clojure/clojure\"`, `\"medley/medley\"`
+  - `:version` _string_ current version 
+  - `:latest-version` _string_ latest version (can be `nil`)
+  - `:repositories` _map_ additional maven repositories (can be `nil`), .e.g.,
+     `{\"nexus-snapshots\" {:url \"http://localhost:8081/repository/maven-snapshots/\"}}`
+  - `:project` _keyword_ project type: `:boot`, `:clojure`, `:clojure-tool`, `:github-action`, `:gradle`, `:leiningen`, `:pom`, `:shadow-cljs`, or `:circle-ci`
+  - `changes-url` _string_ url that describes changes for `:latest-version` (can be `nil`) 
+  - `latest-name` _string_ See https://github.com/clojars/clojars-web/wiki/Verified-Group-Names (can be `nil`)
+  - `only-newest-version?` _boolean_ keep only newest version in same file
+  - `exclude-versions` _sequence of strings_ ignore version that match 
+  - `parent` parent dependency name
 
+  Arguments: 
   - `deps-map` _required_ - A map of the same form as `:deps` in `deps.edn`, e.g.,
     `{org.clojure/clojure {:mvn/version \"1.11.1\"}}`
 
-  - `options` _optional_ - A CLI options map which can also include:
+  - `options` _optional_ - A [CLI options](/README.adoc#options) map which can also include:
      - `:repositories` A map of the same form as `:mvn/repos` in `deps.edn`, e.g.,
         `{\"clojars\" {:url \"https://clojars.org/repo\"}}`"
   ([deps-map]
@@ -32,9 +48,10 @@
   Returns a map as follows:
   `{true [upgraded-deps] false [non-upgraded deps]}`
 
+  Arguments: 
   - `file-dep-pairs` _required_ - A vector of maps, e.g.,
      `{:file \"File path to upgrade\" :dependency outdated-dependency-map}`
-  - `options` _Optional_ - A CLI options map."
+  - `options` _Optional_ - A [CLI options](/README.adoc#options) map."
   ([file-dep-pairs]
    (upgrade-deps! file-dep-pairs {}))
   ([file-dep-pairs options]

--- a/src/antq/api.clj
+++ b/src/antq/api.clj
@@ -9,16 +9,12 @@
 (defn outdated-deps
   "Returns outdated dependencies in the form of `antq.record.Dependency`.
 
-  - deps-map (Required)
-    A map of the same form as `:deps` in deps.edn.
-    E.g. '{org.clojure/clojure {:mvn/version \"1.11.1\"}}
-  - options (Optional)
-    A CLI options map including additional API options.
+  - `deps-map` _required_ - A map of the same form as `:deps` in `deps.edn`, e.g.,
+    `{org.clojure/clojure {:mvn/version \"1.11.1\"}}`
 
-    API options:
-    - repositories
-      A map of the same form as `:mvn/repos` in deps.edn.
-      E.g. {\"clojars\" {:url \"https://clojars.org/repo\"}}"
+  - `options` _optional_ - A CLI options map which can also include:
+     - `:repositories` A map of the same form as `:mvn/repos` in `deps.edn`, e.g.,
+        `{\"clojars\" {:url \"https://clojars.org/repo\"}}`"
   ([deps-map]
    (outdated-deps deps-map {}))
   ([deps-map {:as options :keys [repositories file-path] :or {file-path ""}}]
@@ -32,15 +28,13 @@
 
 (defn upgrade-deps!
   "Upgrade version strings in specified files.
-  Returns a map as follows.
-  {true [upgraded-deps] false [non-upgraded deps]}
 
-  - file-dep-pairs (Required)
-    A vector of maps as follows.
-    {:file \"File path to upgrade\"
-     :dependency outdated-dependency-map}
-  - options (Optional)
-    A CLI options map."
+  Returns a map as follows:
+  `{true [upgraded-deps] false [non-upgraded deps]}`
+
+  - `file-dep-pairs` _required_ - A vector of maps, e.g.,
+     `{:file \"File path to upgrade\" :dependency outdated-dependency-map}`
+  - `options` _Optional_ - A CLI options map."
   ([file-dep-pairs]
    (upgrade-deps! file-dep-pairs {}))
   ([file-dep-pairs options]

--- a/src/antq/api.clj
+++ b/src/antq/api.clj
@@ -51,7 +51,7 @@
   Arguments: 
   - `file-dep-pairs` _required_ - A vector of maps, e.g.,
      `{:file \"File path to upgrade\" :dependency outdated-dependency-map}`
-  - `options` _Optional_ - A [CLI options](/README.adoc#options) map."
+  - `options` _optional_ - A [CLI options](/README.adoc#options) map."
   ([file-dep-pairs]
    (upgrade-deps! file-dep-pairs {}))
   ([file-dep-pairs options]

--- a/src/antq/changelog.clj
+++ b/src/antq/changelog.clj
@@ -1,4 +1,4 @@
-(ns antq.changelog
+(ns ^:no-doc antq.changelog
   (:require
    [antq.log :as log]
    [antq.util.dep :as u.dep]

--- a/src/antq/constant.clj
+++ b/src/antq/constant.clj
@@ -1,4 +1,4 @@
-(ns antq.constant
+(ns ^:no-doc antq.constant
   (:require
    [antq.util.env :as u.env]))
 

--- a/src/antq/constant/github_action.clj
+++ b/src/antq/constant/github_action.clj
@@ -1,4 +1,4 @@
-(ns antq.constant.github-action)
+(ns ^:no-doc antq.constant.github-action)
 
 (def type-key ::type)
 

--- a/src/antq/constant/project_file.clj
+++ b/src/antq/constant/project_file.clj
@@ -1,4 +1,4 @@
-(ns antq.constant.project-file)
+(ns ^:no-doc antq.constant.project-file)
 
 (def babashka "bb.edn")
 (def boot "build.boot")

--- a/src/antq/core.clj
+++ b/src/antq/core.clj
@@ -5,7 +5,7 @@
     (.println ^java.io.PrintWriter *err* "antq requires Clojure 1.10.0 or later.")
     (System/exit 1)))
 
-(ns antq.core
+(ns ^:no-doc antq.core
   (:gen-class)
   (:require
    [antq.changelog :as changelog]

--- a/src/antq/dep/babashka.clj
+++ b/src/antq/dep/babashka.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.babashka
+(ns ^:no-doc antq.dep.babashka
   (:require
    [antq.constant.project-file :as const.project-file]
    [antq.dep.clojure :as dep.clj]

--- a/src/antq/dep/boot.clj
+++ b/src/antq/dep/boot.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.boot
+(ns ^:no-doc antq.dep.boot
   (:require
    [antq.constant :as const]
    [antq.constant.project-file :as const.project-file]

--- a/src/antq/dep/circle_ci.clj
+++ b/src/antq/dep/circle_ci.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.circle-ci
+(ns ^:no-doc antq.dep.circle-ci
   (:require
    [antq.record :as r]
    [antq.util.dep :as u.dep]

--- a/src/antq/dep/clojure.clj
+++ b/src/antq/dep/clojure.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.clojure
+(ns ^:no-doc antq.dep.clojure
   "Clojure CLI"
   (:require
    [antq.constant :as const]

--- a/src/antq/dep/clojure/tool.clj
+++ b/src/antq/dep/clojure/tool.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.clojure.tool
+(ns ^:no-doc antq.dep.clojure.tool
   (:require
    [antq.record :as r]
    [clojure.edn :as edn]

--- a/src/antq/dep/github_action.clj
+++ b/src/antq/dep/github_action.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.github-action
+(ns ^:no-doc antq.dep.github-action
   (:require
    [antq.constant.github-action :as const.gh-action]
    [antq.dep.github-action.matrix :as d.gha.matrix]

--- a/src/antq/dep/github_action/matrix.clj
+++ b/src/antq/dep/github_action/matrix.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.github-action.matrix
+(ns ^:no-doc antq.dep.github-action.matrix
   (:require
    [antq.util.dep :as u.dep]))
 

--- a/src/antq/dep/github_action/third_party.clj
+++ b/src/antq/dep/github_action/third_party.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.github-action.third-party
+(ns ^:no-doc antq.dep.github-action.third-party
   (:require
    [antq.constant.github-action :as const.gh-action]
    [antq.record :as r]

--- a/src/antq/dep/github_action/uses.clj
+++ b/src/antq/dep/github_action/uses.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.github-action.uses
+(ns ^:no-doc antq.dep.github-action.uses
   (:require
    [antq.constant.github-action :as const.gh-action]
    [antq.record :as r]

--- a/src/antq/dep/gradle.clj
+++ b/src/antq/dep/gradle.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.gradle
+(ns ^:no-doc antq.dep.gradle
   (:require
    [antq.constant.project-file :as const.project-file]
    [antq.log :as log]

--- a/src/antq/dep/leiningen.clj
+++ b/src/antq/dep/leiningen.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.leiningen
+(ns ^:no-doc antq.dep.leiningen
   (:require
    [antq.constant :as const]
    [antq.constant.project-file :as const.project-file]

--- a/src/antq/dep/pom.clj
+++ b/src/antq/dep/pom.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.pom
+(ns ^:no-doc antq.dep.pom
   "Clojure CLI"
   (:require
    [antq.constant.project-file :as const.project-file]

--- a/src/antq/dep/shadow.clj
+++ b/src/antq/dep/shadow.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.shadow
+(ns ^:no-doc antq.dep.shadow
   (:require
    [antq.constant :as const]
    [antq.constant.project-file :as const.project-file]

--- a/src/antq/dep/transitive.clj
+++ b/src/antq/dep/transitive.clj
@@ -1,4 +1,4 @@
-(ns antq.dep.transitive
+(ns ^:no-doc antq.dep.transitive
   (:require
    [antq.constant :as const]
    [antq.record :as r]

--- a/src/antq/diff.clj
+++ b/src/antq/diff.clj
@@ -1,4 +1,4 @@
-(ns antq.diff)
+(ns ^:no-doc antq.diff)
 
 (defmulti get-diff-url
   (fn [version-checked-dep]

--- a/src/antq/diff/git_sha.clj
+++ b/src/antq/diff/git_sha.clj
@@ -1,4 +1,4 @@
-(ns antq.diff.git-sha
+(ns ^:no-doc antq.diff.git-sha
   (:require
    [antq.diff :as diff]
    [antq.log :as log]

--- a/src/antq/diff/github_tag.clj
+++ b/src/antq/diff/github_tag.clj
@@ -1,4 +1,4 @@
-(ns antq.diff.github-tag
+(ns ^:no-doc antq.diff.github-tag
   (:require
    [antq.diff :as diff]
    [antq.util.git :as u.git]

--- a/src/antq/diff/java.clj
+++ b/src/antq/diff/java.clj
@@ -1,4 +1,4 @@
-(ns antq.diff.java
+(ns ^:no-doc antq.diff.java
   (:require
    [antq.diff :as diff]
    [antq.log :as log]

--- a/src/antq/download.clj
+++ b/src/antq/download.clj
@@ -1,4 +1,4 @@
-(ns antq.download
+(ns ^:no-doc antq.download
   (:require
    [antq.util.git :as u.git]
    [clojure.tools.deps :as deps]

--- a/src/antq/log.clj
+++ b/src/antq/log.clj
@@ -1,4 +1,4 @@
-(ns antq.log
+(ns ^:no-doc antq.log
   (:require
    [clojure.core.async :as async]))
 

--- a/src/antq/record.clj
+++ b/src/antq/record.clj
@@ -29,6 +29,7 @@
 (def ?dependencies
   [:sequential ?dependency])
 
+;; Also describe in antq.api docstring, carry over any updates there
 (defrecord Dependency
   [;; Dependency type keyword
    ;; e.g. :java, :git-sha or :github-tag

--- a/src/antq/record.clj
+++ b/src/antq/record.clj
@@ -1,4 +1,4 @@
-(ns antq.record)
+(ns ^:no-doc antq.record)
 
 (def ?repository
   [:map [:url 'string?]])

--- a/src/antq/record.clj
+++ b/src/antq/record.clj
@@ -29,7 +29,7 @@
 (def ?dependencies
   [:sequential ?dependency])
 
-;; Also describe in antq.api docstring, carry over any updates there
+;; Also described in antq.api docstring, carry over any updates there
 (defrecord Dependency
   [;; Dependency type keyword
    ;; e.g. :java, :git-sha or :github-tag

--- a/src/antq/report.clj
+++ b/src/antq/report.clj
@@ -1,4 +1,4 @@
-(ns antq.report
+(ns ^:no-doc antq.report
   (:require
    [antq.log :as log]))
 

--- a/src/antq/report/edn.clj
+++ b/src/antq/report/edn.clj
@@ -1,4 +1,4 @@
-(ns antq.report.edn
+(ns ^:no-doc antq.report.edn
   (:require
    [antq.report :as report]))
 

--- a/src/antq/report/format.clj
+++ b/src/antq/report/format.clj
@@ -1,4 +1,4 @@
-(ns antq.report.format
+(ns ^:no-doc antq.report.format
   (:require
    [antq.report :as report]
    [antq.util.dep :as u.dep]

--- a/src/antq/report/json.clj
+++ b/src/antq/report/json.clj
@@ -1,4 +1,4 @@
-(ns antq.report.json
+(ns ^:no-doc antq.report.json
   (:require
    [antq.report :as report]
    [clojure.data.json :as json]))

--- a/src/antq/report/table.clj
+++ b/src/antq/report/table.clj
@@ -1,4 +1,4 @@
-(ns antq.report.table
+(ns ^:no-doc antq.report.table
   (:require
    [antq.log :as log]
    [antq.report :as report]

--- a/src/antq/tool.clj
+++ b/src/antq/tool.clj
@@ -1,4 +1,4 @@
-(ns antq.tool
+(ns ^:no-doc antq.tool
   (:require
    [antq.core :as core]
    [antq.log :as log]

--- a/src/antq/upgrade.clj
+++ b/src/antq/upgrade.clj
@@ -1,4 +1,4 @@
-(ns antq.upgrade
+(ns ^:no-doc antq.upgrade
   (:require
    [antq.dep.github-action :as dep.gh-action]
    [antq.download :as download]

--- a/src/antq/upgrade/boot.clj
+++ b/src/antq/upgrade/boot.clj
@@ -1,4 +1,4 @@
-(ns antq.upgrade.boot
+(ns ^:no-doc antq.upgrade.boot
   (:require
    [antq.constant :as const]
    [antq.upgrade :as upgrade]

--- a/src/antq/upgrade/circle_ci.clj
+++ b/src/antq/upgrade/circle_ci.clj
@@ -1,4 +1,4 @@
-(ns antq.upgrade.circle-ci
+(ns ^:no-doc antq.upgrade.circle-ci
   (:require
    [antq.upgrade :as upgrade]
    [clojure.string :as str]

--- a/src/antq/upgrade/clojure.clj
+++ b/src/antq/upgrade/clojure.clj
@@ -1,4 +1,4 @@
-(ns antq.upgrade.clojure
+(ns ^:no-doc antq.upgrade.clojure
   (:require
    [antq.constant :as const]
    [antq.upgrade :as upgrade]

--- a/src/antq/upgrade/clojure/tool.clj
+++ b/src/antq/upgrade/clojure/tool.clj
@@ -1,4 +1,4 @@
-(ns antq.upgrade.clojure.tool
+(ns ^:no-doc antq.upgrade.clojure.tool
   (:require
    [antq.upgrade :as upgrade]
    [antq.util.git :as u.git]

--- a/src/antq/upgrade/github_action.clj
+++ b/src/antq/upgrade/github_action.clj
@@ -1,4 +1,4 @@
-(ns antq.upgrade.github-action
+(ns ^:no-doc antq.upgrade.github-action
   (:require
    [antq.constant.github-action :as const.gh-action]
    [antq.dep.github-action :as dep.gh-action]

--- a/src/antq/upgrade/leiningen.clj
+++ b/src/antq/upgrade/leiningen.clj
@@ -1,4 +1,4 @@
-(ns antq.upgrade.leiningen
+(ns ^:no-doc antq.upgrade.leiningen
   (:require
    [antq.constant :as const]
    [antq.upgrade :as upgrade]

--- a/src/antq/upgrade/pom.clj
+++ b/src/antq/upgrade/pom.clj
@@ -1,4 +1,4 @@
-(ns antq.upgrade.pom
+(ns ^:no-doc antq.upgrade.pom
   (:require
    [antq.log :as log]
    [antq.upgrade :as upgrade]

--- a/src/antq/upgrade/shadow.clj
+++ b/src/antq/upgrade/shadow.clj
@@ -1,4 +1,4 @@
-(ns antq.upgrade.shadow
+(ns ^:no-doc antq.upgrade.shadow
   (:require
    [antq.constant :as const]
    [antq.upgrade :as upgrade]

--- a/src/antq/util/async.clj
+++ b/src/antq/util/async.clj
@@ -1,4 +1,4 @@
-(ns antq.util.async
+(ns ^:no-doc antq.util.async
   (:require
    [antq.util.exception :as u.ex]
    [clojure.core.async :as async]))

--- a/src/antq/util/dep.clj
+++ b/src/antq/util/dep.clj
@@ -1,4 +1,4 @@
-(ns antq.util.dep
+(ns ^:no-doc antq.util.dep
   (:require
    [antq.util.function :as u.fn]
    [antq.util.maven :as u.mvn]

--- a/src/antq/util/env.clj
+++ b/src/antq/util/env.clj
@@ -1,4 +1,4 @@
-(ns antq.util.env)
+(ns ^:no-doc antq.util.env)
 
 (defn getenv
   [x]

--- a/src/antq/util/exception.clj
+++ b/src/antq/util/exception.clj
@@ -1,4 +1,4 @@
-(ns antq.util.exception
+(ns ^:no-doc antq.util.exception
   (:import
    clojure.lang.ExceptionInfo))
 

--- a/src/antq/util/file.clj
+++ b/src/antq/util/file.clj
@@ -1,4 +1,4 @@
-(ns antq.util.file
+(ns ^:no-doc antq.util.file
   (:require
    [antq.constant.project-file :as const.project-file]
    [antq.util.env :as u.env]

--- a/src/antq/util/function.clj
+++ b/src/antq/util/function.clj
@@ -1,4 +1,4 @@
-(ns antq.util.function)
+(ns ^:no-doc antq.util.function)
 
 (defn memoize-by
   [f key-fn]

--- a/src/antq/util/git.clj
+++ b/src/antq/util/git.clj
@@ -1,4 +1,4 @@
-(ns antq.util.git
+(ns ^:no-doc antq.util.git
   (:require
    [antq.constant :as const]
    [antq.log :as log]

--- a/src/antq/util/leiningen.clj
+++ b/src/antq/util/leiningen.clj
@@ -1,4 +1,4 @@
-(ns antq.util.leiningen
+(ns ^:no-doc antq.util.leiningen
   (:require
    [antq.log :as log]
    [antq.util.env :as u.env]

--- a/src/antq/util/maven.clj
+++ b/src/antq/util/maven.clj
@@ -1,4 +1,4 @@
-(ns antq.util.maven
+(ns ^:no-doc antq.util.maven
   (:require
    [antq.constant :as const]
    [antq.log :as log]

--- a/src/antq/util/report.clj
+++ b/src/antq/util/report.clj
@@ -1,4 +1,4 @@
-(ns antq.util.report
+(ns ^:no-doc antq.util.report
   (:require
    [antq.record :as r]))
 

--- a/src/antq/util/url.clj
+++ b/src/antq/util/url.clj
@@ -1,4 +1,4 @@
-(ns antq.util.url
+(ns ^:no-doc antq.util.url
   (:require
    [clojure.string :as str]))
 

--- a/src/antq/util/ver.clj
+++ b/src/antq/util/ver.clj
@@ -1,4 +1,4 @@
-(ns antq.util.ver
+(ns ^:no-doc antq.util.ver
   (:require
    [antq.util.exception :as u.ex]
    [clojure.string :as str]))

--- a/src/antq/util/xml.clj
+++ b/src/antq/util/xml.clj
@@ -1,4 +1,4 @@
-(ns antq.util.xml)
+(ns ^:no-doc antq.util.xml)
 
 (defn xml-ns
   "expects the result of `xml-seq` as content"

--- a/src/antq/util/zip.clj
+++ b/src/antq/util/zip.clj
@@ -1,4 +1,4 @@
-(ns antq.util.zip
+(ns ^:no-doc antq.util.zip
   (:require
    [clojure.zip :as zip]
    [rewrite-clj.zip :as z]))

--- a/src/antq/ver.clj
+++ b/src/antq/ver.clj
@@ -1,4 +1,4 @@
-(ns antq.ver
+(ns ^:no-doc antq.ver
   (:require
    [clojure.string :as str]
    [version-clj.core :as version]))

--- a/src/antq/ver/circle_ci_orb.clj
+++ b/src/antq/ver/circle_ci_orb.clj
@@ -1,4 +1,4 @@
-(ns antq.ver.circle-ci-orb
+(ns ^:no-doc antq.ver.circle-ci-orb
   (:require
    [antq.log :as log]
    [antq.ver :as ver]

--- a/src/antq/ver/git_sha.clj
+++ b/src/antq/ver/git_sha.clj
@@ -1,4 +1,4 @@
-(ns antq.ver.git-sha
+(ns ^:no-doc antq.ver.git-sha
   (:require
    [antq.util.exception :as u.ex]
    [antq.util.git :as u.git]

--- a/src/antq/ver/git_tag_and_sha.clj
+++ b/src/antq/ver/git_tag_and_sha.clj
@@ -1,4 +1,4 @@
-(ns antq.ver.git-tag-and-sha
+(ns ^:no-doc antq.ver.git-tag-and-sha
   (:require
    [antq.util.exception :as u.ex]
    [antq.util.git :as u.git]

--- a/src/antq/ver/github_tag.clj
+++ b/src/antq/ver/github_tag.clj
@@ -1,4 +1,4 @@
-(ns antq.ver.github-tag
+(ns ^:no-doc antq.ver.github-tag
   (:require
    [antq.constant :as const]
    [antq.log :as log]

--- a/src/antq/ver/java.clj
+++ b/src/antq/ver/java.clj
@@ -1,4 +1,4 @@
-(ns antq.ver.java
+(ns ^:no-doc antq.ver.java
   (:require
    [antq.constant :as const]
    [antq.util.async :as u.async]

--- a/src/leiningen/antq.clj
+++ b/src/leiningen/antq.clj
@@ -1,4 +1,4 @@
-(ns leiningen.antq
+(ns ^:no-doc leiningen.antq
   (:require
    [antq.core]
    [antq.dep.leiningen :as dep.lein]


### PR DESCRIPTION
Hi @liquidz, I reviewed docs, namespaces and docstrings with cljdoc.org in mind.

Details are in commits but in brief:
- all but `antq.api` namespaces have been marked with `:no-doc` metadata to indicate they are not part of the public supported antq API.
- updated docstrings for `antq.api`, let me know what you think, happy to tweak
- added `doc/cljdoc.edn` to describe document tree
- while reviewing tips docs I made some updates, please let me know what you think, happy to tweak more
- added a cljdoc badge to readme, this will go green with the next release of antq

I previewed with cljdoc locally, here's a sneak peek:

![image](https://github.com/user-attachments/assets/b8a91b04-112a-4ae6-bb91-a75d0350d8a9)

Closes #280